### PR TITLE
Make `PropertyWithToString` null-safe

### DIFF
--- a/src/Properties.test.ts
+++ b/src/Properties.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { cell, deref, map, reset } from '@snapview/sunrise'
-import { div } from './Nodes'
+import { div, img } from './Nodes'
 import * as Props from './Properties'
 
 describe('Properties', () => {
@@ -59,5 +59,25 @@ describe('Properties', () => {
 
         reset(!deref(childSource), childSource)
         expect(dynamicPart.subscribers.size).toBe(0)
+    })
+    describe('should not throw an error when a formula cell resolves to a null value', () => {
+        it('when setting an image `src`', () => {
+            // this is an example flow how we might end up with a `null` formula
+            const srcPath = cell('example.jpg')
+            img([Props.src(srcPath)])
+            reset(null, srcPath)
+            img([Props.src(srcPath)])
+        })
+
+        const properties: Array<[string, Props.PropertyWithToString<any>]> = [
+            Props.cssText,
+            Props.htmlFor,
+            Props.placeholder,
+            Props.text,
+            Props.textContent,
+        ].map((fn) => [fn.name, fn])
+        it.each(properties)('when setting`%s`', (_name, fn) => {
+            div([fn(cell(null))])
+        })
     })
 })

--- a/src/Properties.test.ts
+++ b/src/Properties.test.ts
@@ -3,18 +3,18 @@
  */
 import { cell, deref, map, reset } from '@snapview/sunrise'
 import { div } from './Nodes'
-import { children, ReactiveNode, text } from './Properties'
+import * as Props from './Properties'
 
 describe('Properties', () => {
     it('should clean the subscriptions on the same re-created dynamic children when their source is changed', () => {
         const childListSource = cell(false)
         const childSource = cell(false)
 
-        const staticPart = div([text('STATIC DIV')])
-        const dynamicPart = map(() => div([text('DYNAMIC DIV')]), childSource)
+        const staticPart = div([Props.text('STATIC DIV')])
+        const dynamicPart = map(() => div([Props.text('DYNAMIC DIV')]), childSource)
 
         div([
-            children(
+            Props.children(
                 map(() => {
                     return [staticPart, dynamicPart]
                 }, childListSource),
@@ -34,13 +34,13 @@ describe('Properties', () => {
         const childListSource = cell(false)
         const childSource = cell(false)
 
-        const staticPart = div([text('STATIC DIV')])
-        const dynamicPart = map(() => div([text('DYNAMIC DIV')]), childSource)
+        const staticPart = div([Props.text('STATIC DIV')])
+        const dynamicPart = map(() => div([Props.text('DYNAMIC DIV')]), childSource)
 
         div([
-            children(
+            Props.children(
                 map((shouldAddDynamicPart) => {
-                    const content: ReactiveNode[] = [staticPart]
+                    const content: Props.ReactiveNode[] = [staticPart]
                     if (shouldAddDynamicPart) {
                         content.push(dynamicPart)
                     }

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -40,7 +40,7 @@ export type ReactiveNode = Value<Node>
 export type Children = Value<ReactiveNode[]>
 
 type PropertyWithToString<E extends HTMLElement> = <S extends { toString: () => string }>(
-    withToString: Value<S>,
+    withToString: Value<S | null>,
 ) => Property<E>
 
 // -- Property constructors --
@@ -60,7 +60,7 @@ const createBooleanProperty =
 
 const createStringAttr: <E extends HTMLElement>(attrName: string) => PropertyWithToString<E> =
     (attrName: string) => (s) => (element) =>
-        formula((s) => element.setAttribute(attrName, s.toString()), s)
+        formula((s) => element.setAttribute(attrName, s?.toString() ?? ''), s)
 
 // -- Some useful properties --
 
@@ -88,10 +88,10 @@ export const style =
         }, value)
 
 export const cssText: PropertyWithToString<HTMLElement> = (text) => (element) =>
-    formula((text) => (element.style.cssText = text.toString()), text)
+    formula((text) => (element.style.cssText = text?.toString() ?? ''), text)
 
 export const src: PropertyWithToString<HTMLImageElement> = (src) => (element) =>
-    formula((src) => (element.src = src.toString()), src)
+    formula((src) => (element.src = src?.toString() ?? ''), src)
 
 export const classList =
     <E extends { classList: DOMTokenList }>(classes: { [key: string]: Value<boolean> }) =>
@@ -240,14 +240,14 @@ export const value: (
         formula((val) => (element.value = val ?? ''), val)
 
 export const text: PropertyWithToString<HTMLElement> = (innerText) => (element) =>
-    formula((innerText) => (element.innerText = innerText.toString()), innerText)
+    formula((innerText) => (element.innerText = innerText?.toString() ?? ''), innerText)
 
 export const textContent: PropertyWithToString<HTMLElement> = (txt) => (element) =>
-    formula((txt) => (element.textContent = txt.toString()), txt)
+    formula((txt) => (element.textContent = txt?.toString() ?? ''), txt)
 
 export const placeholder: PropertyWithToString<HTMLInputElement | HTMLTextAreaElement> =
     (txt) => (element) =>
-        formula((txt) => (element.placeholder = txt.toString()), txt)
+        formula((txt) => (element.placeholder = txt?.toString() ?? ''), txt)
 
 export const inputType: (t: Value<HTMLInputElement['type']>) => Property<HTMLInputElement> =
     (t) => (element) =>
@@ -273,4 +273,4 @@ export const onloadeddata: (fn: Value<(ev: Event) => void>) => Property<HTMLVide
         formula((fn) => (element.onloadeddata = fn), fn)
 
 export const htmlFor: PropertyWithToString<HTMLLabelElement> = (id) => (element) =>
-    formula((id) => (element.htmlFor = id.toString()), id)
+    formula((id) => (element.htmlFor = id?.toString() ?? ''), id)

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -39,7 +39,7 @@ export type Property<T extends HTMLElement> = (element: T) => void
 export type ReactiveNode = Value<Node>
 export type Children = Value<ReactiveNode[]>
 
-type PropertyWithToString<E extends HTMLElement> = <S extends { toString: () => string }>(
+export type PropertyWithToString<E extends HTMLElement> = <S extends { toString: () => string }>(
     withToString: Value<S | null>,
 ) => Property<E>
 


### PR DESCRIPTION
Because we cannot guarantee that property formulas will not become a null value later.   
We had such issues in our production app.

This was extracted from https://gitlab.com/snapview-gmbh/snapview/frontend/session-app/-/merge_requests/243#note_1270370150